### PR TITLE
Fix BatchDispatcher heap removal

### DIFF
--- a/_toolbox/Shared/Batching/BatchDispatcher.cs
+++ b/_toolbox/Shared/Batching/BatchDispatcher.cs
@@ -101,7 +101,7 @@ namespace _t.Shared.Batching
             _groups.Remove(key);
             _deadlines.Remove(key);
             if (_deadlineHeap.Contains(key))
-                _deadlineHeap.ExtractMin();
+                _deadlineHeap.Remove(key);
         }
     }
 }

--- a/_toolbox/Shared/Collections/MiniHeap.cs
+++ b/_toolbox/Shared/Collections/MiniHeap.cs
@@ -67,6 +67,32 @@ namespace _t.Shared.Collections
             return minKey;
         }
 
+        public void Remove(TKey key)
+        {
+            if (!_indexMap.TryGetValue(key, out int index))
+                throw new KeyNotFoundException($"Key '{key}' not found in heap.");
+
+            int lastIndex = _heap.Count - 1;
+            if (index != lastIndex)
+            {
+                var last = _heap[lastIndex];
+                _heap[index] = last;
+                _indexMap[last.Key] = index;
+            }
+
+            _heap.RemoveAt(lastIndex);
+            _indexMap.Remove(key);
+
+            if (index < _heap.Count)
+            {
+                int parent = (index - 1) / 2;
+                if (index > 0 && _comparer.Compare(_heap[index].Priority, _heap[parent].Priority) < 0)
+                    HeapifyUp(index);
+                else
+                    HeapifyDown(index);
+            }
+        }
+
         private void HeapifyUp(int index)
         {
             while (index > 0)


### PR DESCRIPTION
## Summary
- add `Remove` method to `MinHeap` for deleting specific keys
- use `MinHeap.Remove` in `BatchDispatcher.FlushGroup`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a01efebfc832484900b4bd6a34726