### PR TITLE
Add Unity config assets for pooling and caching

### DIFF
--- a/UnityDemo/Assets/Scripts/Caching/CacheExample.cs
+++ b/UnityDemo/Assets/Scripts/Caching/CacheExample.cs
@@ -1,0 +1,23 @@
+using System;
+using UnityEngine;
+using _t.Shared.Caching;
+
+namespace _t.Unity.Caching
+{
+    public class CacheExample : MonoBehaviour
+    {
+        [SerializeField]
+        private CacheSettings CacheConfig;
+
+        private ICache<string, string> _cache;
+
+        private void Awake()
+        {
+            int capacity = CacheConfig != null ? CacheConfig.Capacity : 10;
+            float ttl = CacheConfig != null ? CacheConfig.TtlSeconds : 30f;
+
+            _cache = new Cache<string, string>(capacity, TimeSpan.FromSeconds(ttl));
+            CacheRegistry.Register("example", () => _cache);
+        }
+    }
+}

--- a/UnityDemo/Assets/Scripts/Caching/CacheExample.cs.meta
+++ b/UnityDemo/Assets/Scripts/Caching/CacheExample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 908e9ecf-41a8-4981-937c-a01423e8b5dd

--- a/UnityDemo/Assets/Scripts/Caching/CacheSettings.cs
+++ b/UnityDemo/Assets/Scripts/Caching/CacheSettings.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace _t.Unity.Caching
+{
+    [CreateAssetMenu(fileName = "CacheSettings", menuName = "_t/Cache Settings")]
+    public class CacheSettings : ScriptableObject
+    {
+        [Min(1)]
+        public int Capacity = 10;
+
+        [Tooltip("Time to live in seconds before an entry expires")]
+        [Min(0f)]
+        public float TtlSeconds = 30f;
+    }
+}

--- a/UnityDemo/Assets/Scripts/Caching/CacheSettings.cs.meta
+++ b/UnityDemo/Assets/Scripts/Caching/CacheSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca93ec55-c423-4b73-8450-692ef7d4cd0e

--- a/UnityDemo/Assets/Scripts/ObjectPoolTest.cs
+++ b/UnityDemo/Assets/Scripts/ObjectPoolTest.cs
@@ -7,24 +7,23 @@ namespace _t.Unity
 {
     public class ObjectPoolTest : MonoBehaviour
     {
-        private ObjectPool<int, DamageEvent> _testPool = new ObjectPool<int, DamageEvent>(
-            capacity: 20,
-            ttl: TimeSpan.FromSeconds(10),
-            keyGenerator: () => 0, // dummy key for single-type pool
-            factory: _ => new DamageEvent(),
-            onReturn: e => e.Clear()
-            );
-        
-        void Start()
+        [SerializeField]
+        private PoolSettings PoolConfig;
+
+        private ObjectPool<int, DamageEvent> _testPool;
+
+        private void Awake()
         {
-            var eventPool = new ObjectPool<int,DamageEvent>(
-                capacity: 20,
-                ttl: TimeSpan.FromSeconds(10),
-                keyGenerator: () => 0, // dummy key for single-type pool
+            int capacity = PoolConfig != null ? PoolConfig.Capacity : 20;
+            float ttlSeconds = PoolConfig != null ? PoolConfig.TtlSeconds : 10f;
+
+            _testPool = new ObjectPool<int, DamageEvent>(
+                capacity: capacity,
+                ttl: TimeSpan.FromSeconds(ttlSeconds),
+                keyGenerator: () => 0,
                 factory: _ => new DamageEvent(),
                 onReturn: e => e.Clear()
             );
         }
     }
 }
-

--- a/UnityDemo/Assets/Scripts/Pooling/PoolSettings.cs
+++ b/UnityDemo/Assets/Scripts/Pooling/PoolSettings.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace _t.Unity.ObjectPool
+{
+    [CreateAssetMenu(fileName = "PoolSettings", menuName = "_t/Pool Settings")]
+    public class PoolSettings : ScriptableObject
+    {
+        [Min(1)]
+        public int Capacity = 10;
+
+        [Tooltip("Time to live in seconds for returned objects before reuse")] 
+        [Min(0f)]
+        public float TtlSeconds = 10f;
+    }
+}

--- a/UnityDemo/Assets/Scripts/Pooling/PoolSettings.cs.meta
+++ b/UnityDemo/Assets/Scripts/Pooling/PoolSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45d15e46-570a-41e2-8468-0445ab0f17f0


### PR DESCRIPTION
## Summary
- introduce `PoolSettings` and `CacheSettings` ScriptableObjects
- update `ObjectPoolTest` to use a `PoolSettings` asset
- add `CacheExample` MonoBehaviour demonstrating cache settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4b55e5948324a02fb6aa9f7a7950